### PR TITLE
Use the AWS Public ECR mirror of Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM public.ecr.aws/lts/ubuntu:24.04
 
 ENV ARCH=arm64
 ENV CROSS_COMPILE=aarch64-linux-gnu-


### PR DESCRIPTION
To avoid Docker Hub rate limit issue, using aws public ecr mirror