### PR TITLE
Dockerfile: Add b4 and u-boot-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV CROSS_COMPILE=aarch64-linux-gnu-
 COPY generate_boot_bins.sh /usr/bin
 
 RUN apt-get update && \
-    apt-get install -y build-essential git clang-15 lld-15 flex bison bc libssl-dev curl kmod systemd-ukify rsync mtools dosfstools lavacli && \
+    apt-get install -y build-essential git clang-15 lld-15 flex bison bc libssl-dev curl kmod systemd-ukify rsync mtools dosfstools lavacli u-boot-tools b4 && \
     apt-get install -y gcc-aarch64-linux-gnu && \
     apt-get install -y python3-pip swig yamllint && \
     apt install -y python3-setuptools python3-wheel && \


### PR DESCRIPTION
Add b4 and u-boot-tools to the Docker image to support patch workflows and boot image generation.
