### PR TITLE
build.sh: Copy vmlinux in images directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 
 ### Add user to the docker group
 ```
+sudo groupadd docker
 sudo usermod -aG docker $USER
 newgrp docker
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -77,6 +77,7 @@ fi
 echo "Adding current user to docker group..."
 sudo groupadd docker || true
 sudo usermod -aG docker $USER
+newgrp docker
 
 echo "Building Docker image..."
 docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg USER_NAME=$(whoami) -t kmake-image .


### PR DESCRIPTION
To preserve vmlinux for dump usecases for corresponding images bins.