### PR TITLE
CI: add Dockerfile and README to support image packing in CI pipeline

### DIFF
--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:24.04
+
+ARG USER_ID
+ARG GROUP_ID
+ARG USER_NAME
+
+RUN if [ -n "$USER_ID" ] && [ -n "$GROUP_ID" ] && [ -n "$USER_NAME" ]; then \
+        groupadd -g "$GROUP_ID" "$USER_NAME" && \
+        useradd -m -u "$USER_ID" -g "$GROUP_ID" -d / "$USER_NAME" ; \
+    fi
+
+ENV ARCH=arm64
+ENV CROSS_COMPILE=aarch64-linux-gnu-
+
+COPY generate_boot_bins.sh /usr/bin/
+COPY build.sh /usr/bin/
+COPY make_fitimage.sh /usr/bin/
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        binutils \
+        python3 \
+        locales \
+        kmod \
+        rsync \
+        systemd-ukify \
+        dosfstools \
+        mtools \
+        cpio \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    locale-gen en_US.UTF-8; \
+    update-locale LANG=en_US.UTF-8; \
+    \
+    curl "https://android.googlesource.com/platform/system/tools/mkbootimg/+/refs/heads/android12-release/mkbootimg.py?format=TEXT" \
+      | base64 --decode > /usr/bin/mkbootimg; \
+    chmod +x /usr/bin/mkbootimg; \
+    chmod 755 /usr/bin/generate_boot_bins.sh /usr/bin/build.sh /usr/bin/make_fitimage.sh; \
+    \
+    command -v ukify; \
+    command -v mkfs.vfat; \
+    command -v mcopy; \
+    command -v rsync
+
+# Fetch & unpack systemd-boot .deb
+ARG SYSTEMD_BOOT_DEB_URL="http://ports.ubuntu.com/pool/universe/s/systemd/systemd-boot-efi_255.4-1ubuntu8_arm64.deb"
+RUN set -eux; \
+    mkdir -p /artifacts/systemd; \
+    echo "Downloading systemd-boot from: ${SYSTEMD_BOOT_DEB_URL}"; \
+    curl -fsSL "${SYSTEMD_BOOT_DEB_URL}" -o /artifacts/systemd-boot-efi.deb; \
+    dpkg-deb -xv /artifacts/systemd-boot-efi.deb /artifacts/systemd; \
+    test -d /artifacts/systemd/usr/lib/systemd/boot/efi
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8

--- a/CI/README.md
+++ b/CI/README.md
@@ -1,0 +1,99 @@
+# kmake-image-packager
+
+Docker image for packaging bootable Linux kernel artifacts.
+
+This project focuse on generating bootable images (`efi.bin`, `dtb.bin`) from prebuilt kernel artifacts (kernel image and DTB).
+
+
+# TL;DR (Step-by-Step)
+
+
+### 1. Clone kmake-image
+
+```bash
+git clone git@github.com:qualcomm-linux/kmake-image.git
+cd kmake-image
+```
+
+### 2. Build the Docker Image
+
+You can build the Docker image in one of the following ways.
+
+#### Option A: Simple build
+
+```bash
+docker build -f CI/Dockerfile.ci -t kmake-image-ci .
+```
+
+#### Option B: Build with user mapping (recommended)
+
+This avoids file permission issues on generated artifacts.
+
+```bash
+docker build \
+  --build-arg USER_ID=$(id -u) \
+  --build-arg GROUP_ID=$(id -g) \
+  --build-arg USER_NAME=$(whoami) \
+  -f CI/Dockerfile.ci \
+  -t kmake-image-ci .
+```
+
+### 3. Set up the alias in your `.bashrc`
+
+Add the following alias:
+
+```bash
+alias kmake-image-ci='docker run -it --rm \
+  --user $(id -u):$(id -g) \
+  --workdir="$PWD" \
+  -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
+  kmake-image-ci'
+```
+
+Apply the change:
+
+```bash
+source ~/.bashrc
+```
+
+### Prerequisites (Required Artifacts)
+
+Before generating `efi.bin`, ensure the following artifacts are available locally:
+
+- **Kernel Image**: `Image` (uncompressed)
+- **Ramdisk**: `initrd.cpio.gz`
+- **Target DTB**: example `qcs6490-rb3gen2.dtb`
+
+### 4. Generate `efi.bin`
+
+Run the EFI image generation command:
+
+```bash
+kmake-image-ci generate_boot_bins.sh efi \
+  --ramdisk artifacts/initrd.cpio.gz \
+  --systemd-boot /artifacts/systemd/usr/lib/systemd/boot/efi/systemd-bootaa64.efi \
+  --stub /artifacts/systemd/usr/lib/systemd/boot/efi/linuxaa64.efi.stub \
+  --linux artifacts/Image \
+  --cmdline "console=ttyMSM0,115200n8 copy-modules rootdelay=10 root=PARTLABEL=rootfs rw rootwait qcom_geni_serial.con_enabled=1" \
+  --output images
+```
+
+### 5. Generate `dtb.bin`
+*(For targets supporting a DTB partition)*
+
+```bash
+kmake-image-ci generate_boot_bins.sh dtb \
+  --input artifacts/qcs6490-rb3gen2.dtb \
+  --output images
+```
+
+### 6. Output
+
+The generated files:
+
+- `efi.bin`
+- `dtb.bin`
+
+are available in the `images/` directory and are ready to be booted on
+**QCS6490 RB3Gen2**.
+


### PR DESCRIPTION
Add a CI Dockerfile to generate  efi.bin and dtb.bin from pre-build kernel artifacts.